### PR TITLE
Add caps lock indicator to hyprlock, manage hypridle via systemd

### DIFF
--- a/.config/hypr/conf/autostart.conf
+++ b/.config/hypr/conf/autostart.conf
@@ -12,7 +12,7 @@ exec-once = hyprpaper
 exec-once = dunst
 
 # Using hypridle to start hyprlock
-exec-once = hypridle
+exec-once = systemctl --user start hypridle
 
 # Load cliphist history
 exec-once = wl-paste --watch cliphist store

--- a/.config/hypr/hyprlock.conf
+++ b/.config/hypr/hyprlock.conf
@@ -37,13 +37,23 @@ input-field {
     fail_color = $error # if authentication failed, changes outer_color and fail message color
     fail_text = <i>$FAIL <b>($ATTEMPTS)</b></i> # can be set to empty
     fail_transition = 300 # transition time in ms between normal outer_color and fail_color
-#TODO: FIXME
-    capslock_color = -1
+    capslock_color = $error
     numlock_color = -1
     bothlock_color = -1 # when both locks are active. -1 means don't change outer color (same for above)
     invert_numlock = false # change color if numlock is off
     swap_font_color = false # see below
     position = 0, -20
+    halign = center
+    valign = center
+}
+
+label {
+    monitor =
+    text = cmd[update:200] cat /sys/class/leds/*::capslock/brightness 2>/dev/null | grep -qx 1 && echo "  CAPS LOCK  " || echo ""
+    color = $error
+    font_size = 18
+    font_family = JetBrainsMono
+    position = 0, 40
     halign = center
     valign = center
 }


### PR DESCRIPTION
Set capslock_color to $error so the input field border turns red when caps lock is active. Add a text label above the input field that polls /sys/class/leds/*::capslock/brightness and shows "CAPS LOCK" in the error color when active. Switch hypridle from exec-once binary launch to systemctl --user start so systemd tracks and manages the process while Hyprland still controls startup timing.


Claude-Session: https://claude.ai/code/session_01779cEAraQXLQEy3pf5uvQB